### PR TITLE
Enable debug text in BotController

### DIFF
--- a/BuildABot/Ancestors/Bot.cs
+++ b/BuildABot/Ancestors/Bot.cs
@@ -10,4 +10,19 @@ namespace Ancestors
         void OnEnd(ResponseObservation observation, Result result);
         void OnStart(ResponseGameInfo gameInfo, ResponseData data, ResponsePing pingResponse, ResponseObservation observation, uint playerId, String opponentId);
     }
+
+    /// <summary>
+    /// Optional interface for bots that want to send SC2 debug drawing commands.
+    /// Implementing this allows <see cref="GameConnection"/> to fetch a
+    /// <see cref="SC2APIProtocol.Request"/> containing debug information each
+    /// frame and send it to the game.
+    /// </summary>
+    public interface IDebugProvider
+    {
+        /// <summary>
+        /// Retrieve the debug request for the current frame. Return
+        /// <c>null</c> if there are no debug commands to send.
+        /// </summary>
+        Request? GetDebugRequest();
+    }
 }

--- a/BuildABot/Ancestors/GameConnection.cs
+++ b/BuildABot/Ancestors/GameConnection.cs
@@ -214,6 +214,14 @@ namespace Ancestors
                 if (actionRequest.Action.Actions.Count > 0)
                     await proxy.SendRequest(actionRequest);
 
+                // Send debug drawing commands if the bot provides them
+                if (bot is IDebugProvider debugProvider)
+                    {
+                    Request? debugRequest = debugProvider.GetDebugRequest();
+                    if (debugRequest != null)
+                        await proxy.SendRequest(debugRequest);
+                    }
+
                 Request stepRequest = new Request();
                 stepRequest.Step = new RequestStep();
                 stepRequest.Step.Count = 1;

--- a/BuildABot/Controllers/BotController.cs
+++ b/BuildABot/Controllers/BotController.cs
@@ -12,53 +12,6 @@ using Action = SC2APIProtocol.Action;
 namespace Controllers
 {
 
-    public class SimpleDebugService
-        {
-        public Request DrawRequest
-            {
-            get; private set;
-            }
-
-        public void ResetDrawRequest()
-            {
-            DrawRequest = new Request();
-            DrawRequest.Debug = new RequestDebug();
-            DebugCommand debugCommand = new DebugCommand();
-            debugCommand.Draw = new DebugDraw();
-            DrawRequest.Debug.Debug.Add(debugCommand);
-            }
-
-        public void DrawCircle(Point2D pos, float radius, Color color)
-            {
-            var point = new Point { X = pos.X, Y = pos.Y, Z = 8.0f };
-            DrawRequest.Debug.Debug[0].Draw.Spheres.Add(new DebugSphere()
-                {
-                Color = color,
-                R = radius,
-                P = point
-                });
-            }
-        public void DrawSphere(Point point, float radius = 2, Color color = null)
-            {
-             DrawRequest.Debug.Debug[0].Draw.Spheres.Add(new DebugSphere()
-                {
-                Color = color,
-                R = radius,
-                P = point
-                });
-            }
-        public void DrawText(string text, Point pos, Color color, uint size = 12)
-            {
-            DrawRequest.Debug.Debug[0].Draw.Text.Add(new DebugText()
-                {
-                Size = size,
-                Color = color,
-                Text = text,
-                WorldPos = pos
-                });
-            }
-
-        }
     /// <summary>
     /// High‑level bot controller implementing the SC2API_CSharp.Bot interface.  This
     /// class exposes natural language style methods for training units and
@@ -66,10 +19,9 @@ namespace Controllers
     /// units and delegates production to a ProductionManager.  The OnFrame
     /// method is responsible for keeping these lists up to date each frame.
     /// </summary>
-    public class BotController : Bot
+    public class BotController : Bot, IDebugProvider
     {
-
-        SimpleDebugService debugService = new SimpleDebugService();
+        private readonly DebugService _debugService = new DebugService();
         private readonly ProductionManager _production = new ProductionManager();
         private WallManager _wallManager;
 
@@ -79,7 +31,6 @@ namespace Controllers
         private EnemyIntel _enemyIntel = new EnemyIntel();
 
         private MapAnalysisService MapAnalysisService;
-        private DebugService _debugService;
 
         private SCVMovementTest _scvTest;
         // Empty constructor
@@ -104,8 +55,7 @@ namespace Controllers
            
             _wallManager = new WallManager(gameInfo,MapAnalysisService);
             _wallManager.Initialize(observation);
-             _scvScout = new ScvScoutTask();
-            _debugService = new DebugService();
+            _scvScout = new ScvScoutTask();
 
           //  _scvTest = new SCVMovementTest();
           //  _scvTest.SetTargetPosition(139.5f, 40.5f); // Use your wall position
@@ -122,8 +72,8 @@ namespace Controllers
         {
             List<Action> actions = new List<Action>();
 
-            // Reset debug drawing each frame
-            debugService.ResetDrawRequest();
+            // Clear previous frame's debug commands
+            _debugService.NewFrame();
 
             // Mark all detected ramps on the map
             MarkRampsOnMap();
@@ -162,13 +112,6 @@ namespace Controllers
                 actions.AddRange(_wallManager.MaintainWall(observation, _ourUnits));
             }
 
-            // Add debug drawing request to actions (this sends the visual markers to SC2)
-            if (debugService.DrawRequest.Debug?.Debug?.Count > 0)
-                {
-                // Convert debug request to action (you may need to adjust this based on your SC2 client wrapper)
-                // This is the key part that actually sends the visual markers to StarCraft II
-                yield return new Action { Debug = debugService.DrawRequest.Debug };
-                }
 
             // Insert high level bot logic here.  For example:
             // If we have less than 20 SCVs, produce more SCVs.
@@ -185,13 +128,6 @@ namespace Controllers
                 List<Action> scvActions = _production.CreateUnit(UnitType.SCV, 1);
                 actions.AddRange(scvActions);
             }
-
-            // Important: Reset debug drawing each frame if using visual debugging
-            if (debugService != null)
-                {
-                debugService.ResetDrawRequest();
-                }
-
 
             // Return all actions including debug drawing
             foreach (var action in actions)
@@ -289,13 +225,23 @@ namespace Controllers
             foreach (var ramp in MapAnalysisService.Ramps)
                 {
                 // Draw red circle at each ramp location
-                debugService.DrawCircle(ramp, 3.0f, redColor);
+                var rampPoint = new Point { X = ramp.X, Y = ramp.Y, Z = 8.0f };
+                _debugService.DrawSphere(rampPoint, 3.0f, redColor);
 
-                // Optional: Add text label
-                var point = new Point { X = ramp.X, Y = ramp.Y, Z = 10.0f };
-                debugService.DrawText("RAMP", point, redColor, 12);
+                // Optional: Add text label above the ramp
+                var textPoint = new Point { X = ramp.X, Y = ramp.Y, Z = 10.0f };
+                _debugService.DrawText("RAMP", textPoint, redColor, 12);
                 }
             }
         }
+
+        /// <summary>
+        /// Provide the debug request for the current frame.
+        /// </summary>
+        public Request? GetDebugRequest()
+            {
+            return _debugService.CreateDebugRequest();
+            }
+    }
 
 }


### PR DESCRIPTION
## Summary
- create `IDebugProvider` interface for debug commands
- send debug requests from `GameConnection`
- use the new debug service within `BotController` and expose a debug request
- remove old `SimpleDebugService` helper

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841cc594f08333be56bd4339ae3257