### PR TITLE
Implement debug request handling

### DIFF
--- a/BuildABot/Ancestors/Bot.cs
+++ b/BuildABot/Ancestors/Bot.cs
@@ -9,5 +9,10 @@ namespace Ancestors
         IEnumerable<SC2APIProtocol.Action> OnFrame(ResponseObservation observation);
         void OnEnd(ResponseObservation observation, Result result);
         void OnStart(ResponseGameInfo gameInfo, ResponseData data, ResponsePing pingResponse, ResponseObservation observation, uint playerId, String opponentId);
+        /// <summary>
+        /// Optional debug drawing request for this frame. Can return null when there is
+        /// nothing to draw.
+        /// </summary>
+        Request GetDebugRequest();
     }
 }

--- a/BuildABot/Ancestors/GameConnection.cs
+++ b/BuildABot/Ancestors/GameConnection.cs
@@ -214,6 +214,11 @@ namespace Ancestors
                 if (actionRequest.Action.Actions.Count > 0)
                     await proxy.SendRequest(actionRequest);
 
+                // Send debug drawing commands if the bot has any
+                Request debugRequest = bot.GetDebugRequest();
+                if (debugRequest != null)
+                    await proxy.SendRequest(debugRequest);
+
                 Request stepRequest = new Request();
                 stepRequest.Step = new RequestStep();
                 stepRequest.Step.Count = 1;

--- a/BuildABot/Controllers/BotController.cs
+++ b/BuildABot/Controllers/BotController.cs
@@ -12,53 +12,6 @@ using Action = SC2APIProtocol.Action;
 namespace Controllers
 {
 
-    public class SimpleDebugService
-        {
-        public Request DrawRequest
-            {
-            get; private set;
-            }
-
-        public void ResetDrawRequest()
-            {
-            DrawRequest = new Request();
-            DrawRequest.Debug = new RequestDebug();
-            DebugCommand debugCommand = new DebugCommand();
-            debugCommand.Draw = new DebugDraw();
-            DrawRequest.Debug.Debug.Add(debugCommand);
-            }
-
-        public void DrawCircle(Point2D pos, float radius, Color color)
-            {
-            var point = new Point { X = pos.X, Y = pos.Y, Z = 8.0f };
-            DrawRequest.Debug.Debug[0].Draw.Spheres.Add(new DebugSphere()
-                {
-                Color = color,
-                R = radius,
-                P = point
-                });
-            }
-        public void DrawSphere(Point point, float radius = 2, Color color = null)
-            {
-             DrawRequest.Debug.Debug[0].Draw.Spheres.Add(new DebugSphere()
-                {
-                Color = color,
-                R = radius,
-                P = point
-                });
-            }
-        public void DrawText(string text, Point pos, Color color, uint size = 12)
-            {
-            DrawRequest.Debug.Debug[0].Draw.Text.Add(new DebugText()
-                {
-                Size = size,
-                Color = color,
-                Text = text,
-                WorldPos = pos
-                });
-            }
-
-        }
     /// <summary>
     /// High‑level bot controller implementing the SC2API_CSharp.Bot interface.  This
     /// class exposes natural language style methods for training units and
@@ -69,7 +22,6 @@ namespace Controllers
     public class BotController : Bot
     {
 
-        SimpleDebugService debugService = new SimpleDebugService();
         private readonly ProductionManager _production = new ProductionManager();
         private WallManager _wallManager;
 
@@ -123,7 +75,7 @@ namespace Controllers
             List<Action> actions = new List<Action>();
 
             // Reset debug drawing each frame
-            debugService.ResetDrawRequest();
+            _debugService.NewFrame();
 
             // Mark all detected ramps on the map
             MarkRampsOnMap();
@@ -162,13 +114,6 @@ namespace Controllers
                 actions.AddRange(_wallManager.MaintainWall(observation, _ourUnits));
             }
 
-            // Add debug drawing request to actions (this sends the visual markers to SC2)
-            if (debugService.DrawRequest.Debug?.Debug?.Count > 0)
-                {
-                // Convert debug request to action (you may need to adjust this based on your SC2 client wrapper)
-                // This is the key part that actually sends the visual markers to StarCraft II
-                yield return new Action { Debug = debugService.DrawRequest.Debug };
-                }
 
             // Insert high level bot logic here.  For example:
             // If we have less than 20 SCVs, produce more SCVs.
@@ -186,11 +131,7 @@ namespace Controllers
                 actions.AddRange(scvActions);
             }
 
-            // Important: Reset debug drawing each frame if using visual debugging
-            if (debugService != null)
-                {
-                debugService.ResetDrawRequest();
-                }
+            // Debug drawing requests are sent separately by the game connection
 
 
             // Return all actions including debug drawing
@@ -289,12 +230,20 @@ namespace Controllers
             foreach (var ramp in MapAnalysisService.Ramps)
                 {
                 // Draw red circle at each ramp location
-                debugService.DrawCircle(ramp, 3.0f, redColor);
+                _debugService.DrawSphere(new Point { X = ramp.X, Y = ramp.Y, Z = 8.0f }, 3.0f, redColor);
 
                 // Optional: Add text label
                 var point = new Point { X = ramp.X, Y = ramp.Y, Z = 10.0f };
-                debugService.DrawText("RAMP", point, redColor, 12);
+                _debugService.DrawText("RAMP", point, redColor, 12);
                 }
+            }
+
+        /// <summary>
+        /// Returns the debug drawing request for the current frame.
+        /// </summary>
+        public Request GetDebugRequest()
+            {
+            return _debugService.CreateDebugRequest();
             }
         }
 

--- a/BuildABot/TerranBot/TerranBot.cs
+++ b/BuildABot/TerranBot/TerranBot.cs
@@ -28,6 +28,11 @@ namespace TerranBot
         
         public void OnEnd(ResponseObservation observation, Result result)
         { }
-      
+
+        public Request GetDebugRequest()
+        {
+            return _botController.GetDebugRequest();
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- allow bots to provide a debug request via `GetDebugRequest`
- send debug requests from `GameConnection`
- use `DebugService` inside `BotController` and expose debug requests
- forward debug requests in `TheTerranBot`

## Testing
- `dotnet build BuildABot.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841cc594f08333be56bd4339ae3257