### PR TITLE
Fix ramp detection to store ramp top elevation

### DIFF
--- a/BuildABot/Controllers/BotController.cs
+++ b/BuildABot/Controllers/BotController.cs
@@ -229,11 +229,11 @@ namespace Controllers
 
             foreach (var ramp in MapAnalysisService.Ramps)
                 {
-                // Draw red circle at each ramp location
-                _debugService.DrawSphere(new Point { X = ramp.X, Y = ramp.Y, Z = 8.0f }, 3.0f, redColor);
+                // Draw red circle at each ramp location using the ramp's height
+                _debugService.DrawSphere(new Point { X = ramp.X, Y = ramp.Y, Z = ramp.Z }, 3.0f, redColor);
 
-                // Optional: Add text label
-                var point = new Point { X = ramp.X, Y = ramp.Y, Z = 10.0f };
+                // Optional: Add text label slightly above the ramp top
+                var point = new Point { X = ramp.X, Y = ramp.Y, Z = ramp.Z + 2.0f };
                 _debugService.DrawText("RAMP", point, redColor, 12);
                 }
             }

--- a/BuildABot/Managers/WallManager.cs
+++ b/BuildABot/Managers/WallManager.cs
@@ -532,6 +532,7 @@ namespace Managers
 
             // Only consider ramps that are reasonably close to our main base (within 20 units)
             var nearbyRamps = _mapAnalysis.Ramps
+                .Select(r => new Point2D { X = r.X, Y = r.Y })
                 .Where(ramp => Math.Sqrt(DistanceSquared(_startLoc, ramp)) < 20f)
                 .ToList();
 


### PR DESCRIPTION
## Summary
- track ramp data using `Point` so height info is available
- mark ramps in debug drawing using their stored Z value
- adapt wall manager to work with new ramp type

## Testing
- `bash /tmp/command.sh` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6884231877ac83338c3915981888275e